### PR TITLE
[ENG-3359] Add public APIs for some internals

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -65,10 +65,9 @@ class Connection(object):
                 cls.current = descriptor
             else:
                 existing = rough_dict_get(cls.connections, descriptor)
-            # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
-            cls.current = existing or Connection(descriptor, connect_args, creator)
+                # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
+                cls.current = existing or Connection(descriptor, connect_args, creator)
         else:
-
             if cls.connections:
                 if displaycon:
                     print(cls.connection_list())

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -36,6 +36,9 @@ class Connection(object):
         )
 
     def __init__(self, connect_str=None, connect_args={}, creator=None, name=None):
+        if name and not name.startswith("@"):
+            raise ValueError("name must start with @")
+
         try:
             if creator:
                 engine = sqlalchemy.create_engine(

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -13,7 +13,7 @@ def connection_from_dsn_section(section, config):
     parser = CP.ConfigParser()
     parser.read(config.dsn_filename)
     cfg_dict = dict(parser.items(section))
-    return str(URL(**cfg_dict))
+    return str(URL.create(**cfg_dict))
 
 
 def _connection_string(s, config):
@@ -26,7 +26,7 @@ def _connection_string(s, config):
         parser = CP.ConfigParser()
         parser.read(config.dsn_filename)
         cfg_dict = dict(parser.items(section))
-        return str(URL(**cfg_dict))
+        return str(URL.create(**cfg_dict))
     return ""
 
 

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -331,7 +331,13 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = ("athena", "clickhouse", "ingres", "mssql", "teradata", "vertica")
+_COMMIT_BLACKLIST_DIALECTS = {"athena", "clickhouse", "ingres", "mssql", "teradata", "vertica"}
+
+
+def add_commit_blacklist_dialect(dialect: str):
+    """Add a dialect to the blacklist of dialects that do not support commit."""
+
+    _COMMIT_BLACKLIST_DIALECTS.add(dialect)
 
 
 def _commit(conn, config):

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -380,3 +380,8 @@ def test_connection_set(ip):
 
     result = ip.run_cell_magic("sql", "@test", "SELECT 1")
     assert result == [(1,)]
+
+
+def test_connection_name_must_start_with_at_if_specified():
+    with pytest.raises(ValueError, match="name must start with @"):
+        Connection.set("sqlite:////tmp/test.db", displaycon=False, name="test")

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 import pytest
 
+from sql.connection import Connection
 from sql.magic import SqlMagic
 
 
@@ -370,3 +371,12 @@ def test_multiline_bracket_var_substitution(ip):
         """,
     )
     assert not result
+
+
+def test_connection_set(ip):
+    Connection.set("sqlite:////tmp/test.db", displaycon=False, name="@test")
+    assert "sqlite:////tmp/test.db" not in Connection.connections
+    assert "@test" in Connection.connections
+
+    result = ip.run_cell_magic("sql", "@test", "SELECT 1")
+    assert result == [(1,)]

--- a/src/tests/test_run.py
+++ b/src/tests/test_run.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock
+
+from sql.run import _commit, add_commit_blacklist_dialect
+
+
+class TestAddCommitBlacklistDialect:
+    def test_after_adding_dialect_commit_is_not_issued(self):
+        mock_connection = Mock()
+        mock_connection.dialect = "bigquery"
+        mock_config = Mock()
+        mock_config.autocommit = True
+
+        _commit(mock_connection, mock_config)
+        mock_connection.session.execute.assert_called_once_with("commit")
+        mock_connection.reset_mock()
+
+        add_commit_blacklist_dialect("bigquery")
+        _commit(mock_connection, mock_config)
+        mock_connection.session.execute.assert_not_called()


### PR DESCRIPTION
- `Connection.set` now takes an optional `name` parameter
- Add `add_commit_blacklist_dialect` to update the list of dialects to not `commit`