### PR TITLE
Disallow '+' in dialect blacklist.

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 def unduplicate_field_names(field_names):
-    """Append a number to duplicate field names to make them unique. """
+    """Append a number to duplicate field names to make them unique."""
     res = []
     for k in field_names:
         if k in res:
@@ -265,7 +265,7 @@ class ResultSet(list, ColumnGuesserMixin):
 
     def csv(self, filename=None, **format_params):
         """Generate results in comma-separated form.  Write to ``filename`` if given.
-           Any other parameters will be passed on to csv.writer."""
+        Any other parameters will be passed on to csv.writer."""
         if not self.pretty:
             return None  # no results
         self.pretty.add_rows(self)
@@ -331,11 +331,23 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = {"athena", "clickhouse", "ingres", "mssql", "teradata", "vertica"}
+_COMMIT_BLACKLIST_DIALECTS = {
+    "athena",
+    "clickhouse",
+    "ingres",
+    "mssql",
+    "teradata",
+    "vertica",
+}
 
 
 def add_commit_blacklist_dialect(dialect: str):
     """Add a dialect to the blacklist of dialects that do not support commit."""
+
+    if "+" in dialect:
+        raise ValueError(
+            "Dialects do not have '+' inside (thats a dialect+driver combo)"
+        )
 
     _COMMIT_BLACKLIST_DIALECTS.add(dialect)
 
@@ -360,9 +372,9 @@ def run(conn, sql, config, user_namespace):
             first_word = sql.strip().split()[0].lower()
             if first_word == "begin":
                 raise Exception("ipython_sql does not support transactions")
-            if first_word.startswith("\\") and \
-                    ("postgres" in str(conn.dialect) or \
-                    "redshift" in str(conn.dialect)):
+            if first_word.startswith("\\") and (
+                "postgres" in str(conn.dialect) or "redshift" in str(conn.dialect)
+            ):
                 if not PGSpecial:
                     raise ImportError("pgspecial not installed")
                 pgspecial = PGSpecial()

--- a/src/tests/test_run.py
+++ b/src/tests/test_run.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+from pytest import raises
+
 from sql.run import _commit, add_commit_blacklist_dialect
 
 
@@ -17,3 +19,7 @@ class TestAddCommitBlacklistDialect:
         add_commit_blacklist_dialect("bigquery")
         _commit(mock_connection, mock_config)
         mock_connection.session.execute.assert_not_called()
+
+    def test_hatred_towards_drivernames(self):
+        with raises(ValueError, match=r"Dialects do not have '\+' inside"):
+            add_commit_blacklist_dialect("databricks+connector")


### PR DESCRIPTION
Disallow '+' in dialect names being added to autocommit blacklist, an indication that noteable-magic datasource bootstrapping isn't doing the right thing --- only dialect names ('databricks'), not dialect+driver names ('databricks+connector'), will end up working properly in the blacklist when _commit() decides to actually commit or not.

Followup PR over in noteable-notebook-magic will be raised after this, and then finally a PR in polymorph moving these dependencies forward. This sequence will then make databricks datasource type initially fully operational.