### PR TITLE
Harden executing queries in the face of fatal errors poisoning the connection

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -270,7 +270,7 @@ class SqlMagic(Magics, Configurable):
             #
             # BUT of course sqlite returns ALL errors as OperationalError. Sigh.
 
-            is_fatal = type(e) != ProgrammingError and not (
+            is_fatal = not isinstance(e, ProgrammingError) and not (
                 isinstance(e, OperationalError) and "sqlite" in str(e)
             )
 


### PR DESCRIPTION
 ... by disposing of the connection pool.

Databricks connections can get themselves into a 'forever-broken' state through means I do not fully understand, forever raising DatabaseError exceptions. *Possibly* related to having had the connection open and idle too long (and perhaps the Databricks-side cluster gets auto-decomissioned, and our 'connection' embeds the now-dead cluster handle?).

To recover from this, we need to forcibly 'dispose()' of the connection pool related to the engine/connection.

So, because who knows what other surprises like this we'll find, let's treat all the DBAPI-related exceptions as 'fatal', prompting this sort of closure. Of course, though, SQLite returns *all* errors, including SQL syntax or 'unknown table' errors as one of these sorts of exceptions, so bleh.

Staging notebook https://app.noteable-staging.us/f/82a56acc-1ed2-449c-8766-98dd3ee278df/Hardening%20SQL%20Exceptions%20Experimentation%20Notebook.ipynb was used to develop and test the exception block, against both Databricks (which would sometimes fail or not) and SQLite.

Rachel experienced the original unshakeable Databricks error. This is my attempt to harden to make it shakeable with just re-running the cell.

DatabaseError: Invalid SessionHandle: SessionHandle [b2e561db-e3a8-4c28-8c18-cec3cb14fc88]

Another (future) option could be to ... put the attempt to execute the statement in a bounded loop (like range(2)), and if we eat a fatal error the first time, we just silently dispose() then try again, only  exposing the exception to the user the second time around if it persists (although then the advice to 'just try again' would need to change).